### PR TITLE
Set write_allocate to false

### DIFF
--- a/src/benchmarks.jl
+++ b/src/benchmarks.jl
@@ -9,7 +9,7 @@ function _run_kernels(copy, scale, add, triad;
                       verbose=true,
                       N=default_vector_length(),
                       evals_per_sample=5,
-                      write_allocate=true)
+                      write_allocate=false)
     # initialize
     A, B, C, D, s = zeros(N), zeros(N), zeros(N), zeros(N), rand();
 


### PR DESCRIPTION
Not sure why this is set to true by default.

As far as I can see there is no aliasing or anything that would explain why you would have to count the left-hand-side twice (loading and storing?), it's only stored.