### PR TITLE
Remove dependency on CpuId to support non-x86 CPUs.

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -7,14 +7,12 @@ version = "0.2.0"
 
 [deps]
 BenchmarkTools = "6e4b80f9-dd63-53aa-95a3-0cdb28fa8baf"
-CpuId = "adafc99b-e345-5852-983c-f28acb93d879"
 Downloads = "f43a241f-c20a-4ad4-852c-f6b1247861c6"
 LoopVectorization = "bdcacae8-1622-11e9-2a5c-532679323890"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 
 [compat]
 BenchmarkTools = "0.6, 0.7"
-CpuId = "0.3"
 Downloads = "1.4"
 LoopVectorization = "0.12"
 julia = "1.6"

--- a/src/STREAMBenchmark.jl
+++ b/src/STREAMBenchmark.jl
@@ -1,6 +1,6 @@
 module STREAMBenchmark
 
-using CpuId, BenchmarkTools
+using BenchmarkTools
 using Statistics, Downloads
 using Base.Threads: nthreads, @threads
 using LoopVectorization

--- a/src/benchmarks.jl
+++ b/src/benchmarks.jl
@@ -1,7 +1,7 @@
 """
 Four times the size of the outermost cache (rule of thumb "laid down by Dr. Bandwidth").
 """
-default_vector_length() = Int(4 * last(cachesize()) / sizeof(Float64))
+default_vector_length() = Int(4 * last_cachesize() / sizeof(Float64))
 
 _nthreads_string() = avxt() ? "@avxt" : string(nthreads())
 
@@ -97,6 +97,13 @@ function memory_bandwidth(; verbose=false,
     return nt
 end
 
+function last_cachesize()
+    Base.Cartesian.@nexprs 4 i -> begin
+        cs = Int(LoopVectorization.VectorizationBase.cache_size(Val(i)))
+        cs == 0 || return cs
+    end
+    0
+end
 
 """
     vector_length_dependence(; n=4, evals_per_sample=1) -> Dict
@@ -105,7 +112,7 @@ Measure the memory bandwidth for multiple vector lengths corresponding to
 factors of the size of the outermost cache.
 """
 function vector_length_dependence(; n=4, evals_per_sample=1)
-    outer_cache_size = CpuId.cachesize()[end] / sizeof(Float64)
+    outer_cache_size = last_cachesize() / sizeof(Float64)
     Ns = floor.(Int, range(1,4,length=n) .* outer_cache_size)
     membws = Dict{Int, Float64}()
     for (i, N) in pairs(Ns)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,6 +1,5 @@
 using STREAMBenchmark
 using Test, Statistics
-using CpuId: cachesize
 
 Base.Threads.nthreads() > 1 || (@warn Running test suite with only a single thread!)
 
@@ -15,7 +14,7 @@ use_less_memory = true
 
 @testset "STREAMBenchmark.jl" begin
     @testset "Benchmarks" begin
-        @test STREAMBenchmark.default_vector_length() >= 4*cachesize()[end] / sizeof(Float64)
+        @test STREAMBenchmark.default_vector_length() >= STREAMBenchmark.last_cachesize() / sizeof(Float64)
 
         use_less_memory && (STREAMBenchmark.default_vector_length() = 10)
         @show STREAMBenchmark.default_vector_length()


### PR DESCRIPTION
```julia
julia> using STREAMBenchmark

julia> memory_bandwidth(verbose=true, multithreading=false)
╔══╡ Single-threaded:
╠══╡ (4 threads)
╟─ COPY:  144077.4 MB/s
╟─ SCALE: 144188.3 MB/s
╟─ ADD:   129787.1 MB/s
╟─ TRIAD: 129653.9 MB/s
╟─────────────────────
║ Median: 136932.2 MB/s
╚═════════════════════
(median = 136932.2, minimum = 129653.9, maximum = 144188.3)

julia> versioninfo()
Julia Version 1.8.0-DEV.842
Commit 60e3e5527f* (2021-10-30 05:42 UTC)
Platform Info:
  OS: macOS (arm64-apple-darwin21.1.0)
  CPU: Apple M1
```
While current master cannot precompile on the M1.

Plus, this PR drops a dependency without adding any new ones.