### PR TITLE
Fix last cache, and make multithreaded benchmarks actually run multithreaded.

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,74 +1,39 @@
 stages:
   - test
 
-# This job tests with Julia 1.6
-# + generates and submits code coverage to codecov.io
 julia/1.6:
   stage: test
   tags:
     - bauerc-noctua
   variables:
     SCHEDULER_PARAMETERS: "-A pc2-mitarbeiter -p short"
-  rules:
-    - changes:
-      - "README.md"
-    #   - "docs/**/*.md"
-    #   - "docs/make.jl"
-    #   - "docs/build_docs.jl"
-    #   when: never
-    - when: on_success
+  only:
+    - main
+    - pushes
+    - tags
+    - external_pull_requests
   script:
-    - export JULIA_NUM_THREADS=8
+    - export JULIA_NUM_THREADS=20
     - /bin/bash -l
     - module load lang/Julia/1.6.2-linux-x86_64
     - julia --color=yes --project=. -e 'using Pkg; Pkg.build(verbose=true); Pkg.test(; coverage = true);'
     - julia --color=yes --project=test/coverage -e 'import Pkg; Pkg.instantiate()'
     - julia --color=yes --project=test/coverage test/coverage/coverage.jl
-    # - bash -l
-    # - module load lang/Julia/1.6.2-linux-x86_64
-    # - julia --color=yes --project=. -e 'using Pkg; Pkg.build(verbose=true); Pkg.test(; coverage = true);'
 
-# This job tests with Julia 1.7-rc1
 julia/1.7-rc1:
   stage: test
   tags:
     - bauerc-noctua
   variables:
     SCHEDULER_PARAMETERS: "-A pc2-mitarbeiter -p short"
-  rules:
-    - changes:
-      - "README.md"
-    #   - "docs/**/*.md"
-    #   - "docs/make.jl"
-    #   - "docs/build_docs.jl"
-    #   when: never
-    - when: on_success
+  only:
+    - main
+    - pushes
+    - tags
+    - external_pull_requests
   script:
-    - export JULIA_NUM_THREADS=8
+    - export JULIA_NUM_THREADS=20
     - wget https://julialang-s3.julialang.org/bin/linux/x64/1.7/julia-1.7.0-rc1-linux-x86_64.tar.gz
     - tar --strip-components=1 -xf julia-1.7.0-rc1-linux-x86_64.tar.gz
-    - bin/julia --color=yes --project=. -e 'using Pkg; Pkg.build(verbose=true); Pkg.test(; coverage = true);'
+    - bin/julia --color=yes --project=. -e 'using Pkg; Pkg.build(verbose=true); Pkg.test();'
   allow_failure: true
-
-# julia/nightly:
-#   stage: test
-#   tags:
-#     - bauerc-noctua
-#   variables:
-#     SCHEDULER_PARAMETERS: "-A pc2-mitarbeiter -p short"
-#   rules:
-#     - changes:
-#       - "README.md"
-#     #   - "docs/**/*.md"
-#     #   - "docs/make.jl"
-#     #   - "docs/build_docs.jl"
-#     #   when: never
-#     - when: on_success
-#   script:
-#     - export JULIA_NUM_THREADS=8
-#     - wget https://julialangnightlies-s3.julialang.org/bin/linux/x64/julia-latest-linux64.tar.gz
-#     - tar --strip-components=1 -xf julia-latest-linux64.tar.gz
-#     - bin/julia --color=yes --project=. -e 'using Pkg; Pkg.build(verbose=true); Pkg.test(; coverage = true);'
-#     - bin/julia --color=yes --project=test/coverage -e 'import Pkg; Pkg.instantiate()'
-#     - bin/julia --color=yes --project=test/coverage test/coverage/coverage.jl
-#   allow_failure: true

--- a/Project.toml
+++ b/Project.toml
@@ -3,7 +3,7 @@ uuid = "05e9033e-e298-417a-adae-495536c11ad4"
 license = "MIT"
 desc = "STREAM benchmark to measure the sustainable memory bandwidth."
 authors = ["Carsten Bauer"]
-version = "0.3.0"
+version = "0.3.1"
 
 [deps]
 BenchmarkTools = "6e4b80f9-dd63-53aa-95a3-0cdb28fa8baf"

--- a/src/benchmarks.jl
+++ b/src/benchmarks.jl
@@ -114,12 +114,12 @@ end
 Measure the memory bandwidth for multiple vector lengths corresponding to
 factors of the size of the outermost cache.
 """
-function vector_length_dependence(; n=4, evals_per_sample=1)
+function vector_length_dependence(; n=4, evals_per_sample=1, kwargs...)
     outer_cache_size = last_cachesize() / sizeof(Float64)
     Ns = floor.(Int, range(1, 4; length=n) .* outer_cache_size)
     membws = Dict{Int,Float64}()
     for (i, N) in pairs(Ns)
-        m, _, _ = memory_bandwidth(; N=N, evals_per_sample=evals_per_sample)
+        m, _, _ = memory_bandwidth(; N=N, evals_per_sample=evals_per_sample, kwargs...)
         membws[N] = m
         println(i, ": ", N => m)
     end

--- a/src/benchmarks.jl
+++ b/src/benchmarks.jl
@@ -25,22 +25,22 @@ function _run_kernels(
     g = t -> N * β * 1e-6 / t
 
     # COPY
-    t_copy = @belapsed copy($C, $A) samples = 10 evals = evals_per_sample
+    t_copy = @belapsed $copy($C, $A) samples = 10 evals = evals_per_sample
     bw_copy = f(t_copy)
     verbose && println("╟─ COPY:  ", round(bw_copy; digits=1), " MB/s")
 
     # SCALE
-    t_scale = @belapsed scale($B, $C, $s) samples = 10 evals = evals_per_sample
+    t_scale = @belapsed $scale($B, $C, $s) samples = 10 evals = evals_per_sample
     bw_scale = f(t_scale)
     verbose && println("╟─ SCALE: ", round(bw_scale; digits=1), " MB/s")
 
     # ADD
-    t_add = @belapsed add($C, $A, $B) samples = 10 evals = evals_per_sample
+    t_add = @belapsed $add($C, $A, $B) samples = 10 evals = evals_per_sample
     bw_add = g(t_add)
     verbose && println("╟─ ADD:   ", round(bw_add; digits=1), " MB/s")
 
     # TRIAD
-    t_triad = @belapsed triad($A, $B, $C, $s) samples = 10 evals = evals_per_sample
+    t_triad = @belapsed $triad($A, $B, $C, $s) samples = 10 evals = evals_per_sample
     bw_triad = g(t_triad)
     verbose && println("╟─ TRIAD: ", round(bw_triad; digits=1), " MB/s")
 

--- a/src/benchmarks.jl
+++ b/src/benchmarks.jl
@@ -102,7 +102,7 @@ end
 
 function last_cachesize()
     Base.Cartesian.@nexprs 4 i -> begin
-        cs = Int(LoopVectorization.VectorizationBase.cache_size(Val(i)))
+        cs = Int(LoopVectorization.VectorizationBase.cache_size(Val(5-i)))
         cs == 0 || return cs
     end
     0

--- a/src/original.jl
+++ b/src/original.jl
@@ -33,8 +33,9 @@ function compile_original_STREAM(; compiler=_default_compiler(), multithreading=
     println("- Trying to compile \"stream.c\" using $(string(compiler))")
     if compiler == :clang
         options = [
-            "-Ofast", "-march=native", "-DSTREAM_ARRAY_SIZE=$(default_vector_length())"
+            "-Ofast", "-DSTREAM_ARRAY_SIZE=$(default_vector_length())"
         ] # "-DNTIMES=30"
+        ((Sys.ARCH === :x86_64) || (Sys.ARCH === :i686)) && push!(options, "-march=native")
     elseif compiler == :(gcc - 10) || compiler == :gcc
         options = ["-O3", "-DSTREAM_ARRAY_SIZE=$(default_vector_length())"]
     else

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -16,7 +16,7 @@ use_less_memory = true
     @testset "Benchmarks" begin
         @test STREAMBenchmark.default_vector_length() >= STREAMBenchmark.last_cachesize() / sizeof(Float64)
 
-        use_less_memory && (STREAMBenchmark.default_vector_length() = 1_000_000)
+        use_less_memory && (STREAMBenchmark.default_vector_length() = 10_000)
         @show STREAMBenchmark.default_vector_length()
 
         # memory_bandwidth
@@ -37,7 +37,7 @@ use_less_memory = true
             @test keys(nt.multi) == (:median, :minimum, :maximum)
         end  
         # vector_length_dependence
-        let d = STREAMBenchmark.vector_length_dependence()
+        let d = STREAMBenchmark.vector_length_dependence(multithreading=false)
             @test typeof(d) == Dict{Int64, Float64}
             @test length(d) == 4
             @test maximum(abs.(diff(collect(values(d))))) / median(values(d)) < 0.2

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -24,7 +24,7 @@ use_less_memory = true
         @test 100 < memory_bandwidth().median < 500_000
         @test 100 < memory_bandwidth(multithreading=false).median < 500_000
         with_avxt() do
-            @test 1000 < memory_bandwidth().median < 500_000
+            @test 100 < memory_bandwidth().median < 500_000
         end
 
         # TODO: add verbose=true test

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -16,7 +16,7 @@ use_less_memory = true
     @testset "Benchmarks" begin
         @test STREAMBenchmark.default_vector_length() >= STREAMBenchmark.last_cachesize() / sizeof(Float64)
 
-        use_less_memory && (STREAMBenchmark.default_vector_length() = 10000)
+        use_less_memory && (STREAMBenchmark.default_vector_length() = 100_000)
         @show STREAMBenchmark.default_vector_length()
 
         # memory_bandwidth

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -9,20 +9,20 @@ function with_avxt(f)
     @eval STREAMBenchmark.avxt() = false
 end
 
-use_less_memory = false
+use_less_memory = true
 @show use_less_memory
 
 @testset "STREAMBenchmark.jl" begin
     @testset "Benchmarks" begin
         @test STREAMBenchmark.default_vector_length() >= STREAMBenchmark.last_cachesize() / sizeof(Float64)
 
-        use_less_memory && (STREAMBenchmark.default_vector_length() = 1_000_000)
+        use_less_memory && (STREAMBenchmark.default_vector_length() = 100_000)
         @show STREAMBenchmark.default_vector_length()
 
         # memory_bandwidth
         @test keys(memory_bandwidth()) == (:median, :minimum, :maximum)
-        @test 1000 < memory_bandwidth().median < 500_000
-        @test 1000 < memory_bandwidth(multithreading=false).median < 500_000
+        @test 100 < memory_bandwidth().median < 500_000
+        @test 100 < memory_bandwidth(multithreading=false).median < 500_000
         with_avxt() do
             @test 1000 < memory_bandwidth().median < 500_000
         end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -9,7 +9,7 @@ function with_avxt(f)
     @eval STREAMBenchmark.avxt() = false
 end
 
-use_less_memory = true
+use_less_memory = false
 @show use_less_memory
 
 @testset "STREAMBenchmark.jl" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -16,7 +16,7 @@ use_less_memory = true
     @testset "Benchmarks" begin
         @test STREAMBenchmark.default_vector_length() >= STREAMBenchmark.last_cachesize() / sizeof(Float64)
 
-        use_less_memory && (STREAMBenchmark.default_vector_length() = 10_000)
+        use_less_memory && (STREAMBenchmark.default_vector_length() = 100_000)
         @show STREAMBenchmark.default_vector_length()
 
         # memory_bandwidth

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -16,7 +16,7 @@ use_less_memory = true
     @testset "Benchmarks" begin
         @test STREAMBenchmark.default_vector_length() >= STREAMBenchmark.last_cachesize() / sizeof(Float64)
 
-        use_less_memory && (STREAMBenchmark.default_vector_length() = 100_000)
+        use_less_memory && (STREAMBenchmark.default_vector_length() = 1_000_000)
         @show STREAMBenchmark.default_vector_length()
 
         # memory_bandwidth

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -16,7 +16,7 @@ use_less_memory = true
     @testset "Benchmarks" begin
         @test STREAMBenchmark.default_vector_length() >= STREAMBenchmark.last_cachesize() / sizeof(Float64)
 
-        use_less_memory && (STREAMBenchmark.default_vector_length() = 10)
+        use_less_memory && (STREAMBenchmark.default_vector_length() = 10000)
         @show STREAMBenchmark.default_vector_length()
 
         # memory_bandwidth


### PR DESCRIPTION
The `last_cachesize` method from my previous PR accidentally returned the first cache size instead.