### PR TITLE
more balanced distribution of workload to each thread

### DIFF
--- a/src/benchmarks.jl
+++ b/src/benchmarks.jl
@@ -6,12 +6,21 @@ default_vector_length() = Int(4 * last_cachesize() / sizeof(Float64))
 _nthreads_string(nthreads) = avxt() ? "@avxt" : string(nthreads)
 
 function _threadidcs(N, nthreads)
-    Nperthread = floor(Int, N / nthreads)
+    Nperthread = div(N, nthreads)
     rest = rem(N, nthreads)
-    thread_indices = collect(Iterators.partition(1:N, Nperthread))
-    if rest != 0
-        # last thread compensates for the nonzero remainder
-        thread_indices[end - 1] = (thread_indices[end - 1].start):(thread_indices[end].stop)
+    thread_indices = Vector{UnitRange{Int64}}(undef, nthreads)
+    #
+    # more balanced distribution of workload to each thread
+    #
+    # For example, 10 elements for 4 threads are distributed as:
+    # thread 1 has elements 1 to  3 (3 elements per thread)
+    # thread 2 has elements 4 to  6 (3 elements per thread)
+    # thread 3 has elements 7 to  8 (2 elements per thread)
+    # thread 4 has elements 9 to 10 (2 elements per thread)
+    for i in 1:nthreads
+      thread_indices[i] = i ≤ rest                                    ?
+      (((i - 1) * (Nperthread + 1) +    1):(i * (Nperthread +    1))) :
+      (((i - 1) *  Nperthread + 1  + rest):(i *  Nperthread + rest ))
     end
     return thread_indices
 end

--- a/src/benchmarks.jl
+++ b/src/benchmarks.jl
@@ -6,17 +6,8 @@ default_vector_length() = Int(4 * last_cachesize() / sizeof(Float64))
 _nthreads_string(nthreads) = avxt() ? "@avxt" : string(nthreads)
 
 function _threadidcs(N, nthreads)
-    Nperthread = div(N, nthreads)
-    rest = rem(N, nthreads)
+    Nperthread, rest = divrem(N, nthreads)
     thread_indices = Vector{UnitRange{Int64}}(undef, nthreads)
-    #
-    # more balanced distribution of workload to each thread
-    #
-    # For example, 10 elements for 4 threads are distributed as:
-    # thread 1 has elements 1 to  3 (3 elements per thread)
-    # thread 2 has elements 4 to  6 (3 elements per thread)
-    # thread 3 has elements 7 to  8 (2 elements per thread)
-    # thread 4 has elements 9 to 10 (2 elements per thread)
     for i in 1:nthreads
       thread_indices[i] = i ≤ rest                                    ?
       (((i - 1) * (Nperthread + 1) +    1):(i * (Nperthread +    1))) :


### PR DESCRIPTION
This gives more balanced distribution of workload to each thread than the old function. Here is a concrete example:

10 elements for 4 threads:

- old function gives:
    - thread 1: elements 1 to  2 (2 elements per thread)
    - thread 2: elements 3 to  4 (2 elements per thread)
    - thread 3: elements 5 to  6 (2 elements per thread)
    - thread 4: elements 7 to 10 (4 elements per thread)

- new function gives:
    - thread 1: elements 1 to  3 (3 elements per thread)
    - thread 2: elements 4 to  6 (3 elements per thread)
    - thread 3: elements 7 to  8 (2 elements per thread)
    - thread 4: elements 9 to 10 (2 elements per thread)
