### PR TITLE
Fix `last_cachesize` to be the total size.

### DIFF
--- a/src/benchmarks.jl
+++ b/src/benchmarks.jl
@@ -184,7 +184,7 @@ end
 function last_cachesize()
     Base.Cartesian.@nexprs 4 i->begin
         cs = Int(LoopVectorization.VectorizationBase.cache_size(Val(5 - i)))
-        cs == 0 || return cs
+        cs == 0 || return cs*LoopVectorization.num_cores()
     end
     return 0
 end


### PR DESCRIPTION
`VectorizationBae.cache_size` returns the size per core, so for shared caches, the number is much smaller.

My update therefore assumes that it is shared.

What is the desired behavior?
With this commit, it'll give a size much larger than any actual size on many Ryzen systems, but I think that may be desirable; we don't want the arrays, divided among cores, to fit in the l3s local to the CCXs.